### PR TITLE
Add basic travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+go:
+  -1.x
+services:
+  - mongodb
+git:
+  depth: 3


### PR DESCRIPTION
Sets up a basic .travis.yml for CI config which installs mongodb (for testing)