### PR TITLE
Https

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,7 @@ services:
       - SESSIONKEY=blackcoffee
     ports:
       - "443:443"
+      - "80:80"
     volumes:
       - /etc/letsencrypt:/tls:ro
     container_name: gateway

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - SESSIONKEY=blackcoffee
     ports:
       - "443:443"
+      - "80:80"
     volumes:
       - ./tls:/tls:ro
     container_name: gateway

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -9,6 +9,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gatewaysvc .
 FROM alpine:latest as runner
 RUN apk add --no-cache ca-certificates
 WORKDIR /root/
-EXPOSE 443
+EXPOSE 443 80
 COPY --from=builder /go/src/github.com/KEXPCapstone/shelves-server/gateway .
 ENTRYPOINT ["./gatewaysvc"]


### PR DESCRIPTION
- Listens for http traffic on a separate go routine
- Redirects to https
- Quits gateway w/ logging if ListenAndServe or ListenAndServeTLS fail.
