### PR TITLE
Shelves auth and flags

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -83,7 +83,7 @@ func main() {
 	mux.Handle("/v1/shelves", MicroServiceProxy(splitShelvesSvcAddrs, sessKey, rs))
 	mux.Handle("/v1/shelves/", MicroServiceProxy(splitShelvesSvcAddrs, sessKey, rs))
 
-	mux.Handle("/v1/library/", MicroServiceProxy(splitLibrarySvcAddrs, sessKey, rs))
+	mux.Handle("/v1/library/", UnAuthMicroServiceProxy(splitLibrarySvcAddrs, sessKey, rs))
 
 	corsHandler := handlers.NewCorsHandler(mux)
 	log.Println("Starting to redirect http traffic to https")
@@ -99,6 +99,20 @@ func main() {
 
 func redirectTLS(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "https://"+r.Host+r.RequestURI, http.StatusMovedPermanently)
+}
+
+func UnAuthMicroServiceProxy(addrs []string, signingKey string, sessStore sessions.Store) *httputil.ReverseProxy {
+	index := 0
+	mx := sync.Mutex{}
+	return &httputil.ReverseProxy{
+		Director: func(r *http.Request) {
+			mx.Lock()
+			r.URL.Host = addrs[index%len(addrs)]
+			index++
+			mx.Unlock()
+			r.URL.Scheme = "http" //downgrade to http protocol
+		},
+	}
 }
 
 func MicroServiceProxy(addrs []string, signingKey string, sessStore sessions.Store) *httputil.ReverseProxy {

--- a/shelves/handlers/constants.go
+++ b/shelves/handlers/constants.go
@@ -35,3 +35,5 @@ const UpdatedShelfConf = "Successfully Updated shelf\n"
 const UserShelvesHandlerMethodNotAllowed = "Only allowed to 'GET' from this resource."
 
 const InvalidUserID = "Invalid user ID in request URL."
+
+const FeaturedShelvesHandlerMethodNotAllowed = "Only allowed to 'GET' from this resource."

--- a/shelves/handlers/handlers.go
+++ b/shelves/handlers/handlers.go
@@ -62,16 +62,6 @@ func (hCtx *HandlerCtx) UserShelvesHandler(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-// v1/shelves/featured
-func (hCtx *HandlerCtx) FeaturedShelvesHandler(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-	default:
-		http.Error(w, FeaturedShelvesHandlerMethodNotAllowed, http.StatusMethodNotAllowed)
-		return
-	}
-}
-
 // /v1/shelves/{id}
 func (hCtx *HandlerCtx) ShelfHandler(w http.ResponseWriter, r *http.Request) {
 	shelf, err := hCtx.getShelfFromRequest(r)
@@ -91,6 +81,22 @@ func (hCtx *HandlerCtx) ShelfHandler(w http.ResponseWriter, r *http.Request) {
 		hCtx.deleteShelf(w, r, shelf)
 	default:
 		http.Error(w, ShelfHandlerMethodNotAllowed, http.StatusMethodNotAllowed)
+		return
+	}
+}
+
+// v1/shelves/featured
+func (hCtx *HandlerCtx) FeaturedShelvesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		shelves, err := hCtx.shelfStore.GetFeaturedShelves()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)
+			return
+		}
+		respond(w, http.StatusOK, shelves)
+	default:
+		http.Error(w, FeaturedShelvesHandlerMethodNotAllowed, http.StatusMethodNotAllowed)
 		return
 	}
 }

--- a/shelves/handlers/handlers.go
+++ b/shelves/handlers/handlers.go
@@ -62,6 +62,16 @@ func (hCtx *HandlerCtx) UserShelvesHandler(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+// v1/shelves/featured
+func (hCtx *HandlerCtx) FeaturedShelvesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+	default:
+		http.Error(w, FeaturedShelvesHandlerMethodNotAllowed, http.StatusMethodNotAllowed)
+		return
+	}
+}
+
 // /v1/shelves/{id}
 func (hCtx *HandlerCtx) ShelfHandler(w http.ResponseWriter, r *http.Request) {
 	shelf, err := hCtx.getShelfFromRequest(r)

--- a/shelves/handlers/handlers.go
+++ b/shelves/handlers/handlers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"path"
 
+	"github.com/KEXPCapstone/shelves-server/gateway/models/users"
 	"github.com/KEXPCapstone/shelves-server/shelves/models"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -131,11 +132,15 @@ func (hCtx *HandlerCtx) getShelfFromRequest(r *http.Request) (*models.Shelf, err
 
 func getUserIDFromRequest(r *http.Request) (bson.ObjectId, error) {
 	xUserHeader := r.Header.Get(XUser)
-	if len(xUserHeader) == 0 || !bson.IsObjectIdHex(xUserHeader) {
+	usr := &users.User{}
+	// if err := json.NewDecoder(xUserHeader).Decode(usr); err != nil {
+	// 	return bson.NewObjectId(), fmt.Errorf("Error decoding request body: %v", err)
+	// }
+	json.Unmarshal([]byte(xUserHeader), usr)
+	if len(usr.ID) == 0 {
 		return bson.NewObjectId(), ErrInvalidXUser
 	}
-	userID := bson.ObjectIdHex(xUserHeader)
-	return userID, nil
+	return usr.ID, nil
 }
 
 func (hCtx *HandlerCtx) getUsersShelvesFromID(w http.ResponseWriter, r *http.Request, userID bson.ObjectId) {

--- a/shelves/handlers/handlers.go
+++ b/shelves/handlers/handlers.go
@@ -109,7 +109,7 @@ func (hCtx *HandlerCtx) FeaturedShelvesHandler(w http.ResponseWriter, r *http.Re
 func currUserIsShelfOwner(r *http.Request, shelf *models.Shelf) bool {
 	userID, err := getUserIDFromRequest(r)
 	if err != nil {
-		return false // improve this return, change to err? you want to capture the fact that the user is not authenticated
+		return false
 	}
 	if userID != shelf.OwnerID {
 		return false
@@ -133,10 +133,9 @@ func (hCtx *HandlerCtx) getShelfFromRequest(r *http.Request) (*models.Shelf, err
 func getUserIDFromRequest(r *http.Request) (bson.ObjectId, error) {
 	xUserHeader := r.Header.Get(XUser)
 	usr := &users.User{}
-	// if err := json.NewDecoder(xUserHeader).Decode(usr); err != nil {
-	// 	return bson.NewObjectId(), fmt.Errorf("Error decoding request body: %v", err)
-	// }
-	json.Unmarshal([]byte(xUserHeader), usr)
+	if err := json.Unmarshal([]byte(xUserHeader), usr); err != nil {
+		return bson.NewObjectId(), fmt.Errorf("%v : %v", ErrDecodingJSON, err)
+	}
 	if len(usr.ID) == 0 {
 		return bson.NewObjectId(), ErrInvalidXUser
 	}

--- a/shelves/main.go
+++ b/shelves/main.go
@@ -45,6 +45,7 @@ func main() {
 	mux.HandleFunc("/v1/shelves", hCtx.ShelvesHandler)
 	mux.HandleFunc("/v1/shelves/mine", hCtx.ShelvesMineHandler)
 	mux.HandleFunc("/v1/shelves/users/", hCtx.UserShelvesHandler)
+	mux.HandleFunc("/v1/shelves/featured", hCtx.FeaturedShelvesHandler)
 	mux.HandleFunc("/v1/shelves/", hCtx.ShelfHandler)
 
 	log.Printf("The 'shelves' microservice is listening at http://%s...", addr)

--- a/shelves/models/mongostore.go
+++ b/shelves/models/mongostore.go
@@ -63,7 +63,7 @@ func (ms *MgoStore) GetShelfById(id bson.ObjectId) (*Shelf, error) {
 func (ms *MgoStore) GetUserShelves(userId bson.ObjectId) ([]*Shelf, error) {
 	coll := ms.session.DB(ms.dbname).C(ms.colname)
 	shelves := []*Shelf{}
-	if err := coll.Find(bson.M{"OwnerID": userId}).All(&shelves); err != nil {
+	if err := coll.Find(bson.M{"ownerid": userId}).All(&shelves); err != nil {
 		return nil, fmt.Errorf("%v %v", ErrShelfNotFound, err)
 	}
 	return shelves, nil

--- a/shelves/models/mongostore.go
+++ b/shelves/models/mongostore.go
@@ -103,3 +103,12 @@ func (ms *MgoStore) CopyShelf(id bson.ObjectId, userId bson.ObjectId) (*Shelf, e
 func (ms *MgoStore) ExportShelf(id bson.ObjectId) error {
 	return nil
 }
+
+func (ms *MgoStore) GetFeaturedShelves() ([]*Shelf, error) {
+	coll := ms.session.DB(ms.dbname).C(ms.colname)
+	shelves := []*Shelf{}
+	if err := coll.Find(bson.M{"featured": true}).All(&shelves); err != nil {
+		return nil, fmt.Errorf("%v %v", ErrShelfNotFound, err)
+	}
+	return shelves, nil
+}

--- a/shelves/models/shelf.go
+++ b/shelves/models/shelf.go
@@ -11,7 +11,6 @@ type Shelf struct {
 	ID           bson.ObjectId   `json:"id" bson:"_id"`
 	OwnerID      bson.ObjectId   `json:"ownerId"` // TODO: May have to also add bson tag here
 	Name         string          `json:"name"`
-	Deleted      bool            `json:"-"` // store, but don't encode
 	ReleaseIDs   []bson.ObjectId `json:"releaseIDs"`
 	Description  string          `json:"description"` // Maybe
 	DateCreated  time.Time       `json:"dateCreated"`
@@ -40,7 +39,6 @@ func (ns *NewShelf) ToShelf(userID bson.ObjectId) (*Shelf, error) {
 		ID:           bson.NewObjectId(),
 		OwnerID:      userID,
 		Name:         ns.Name,
-		Deleted:      false,
 		ReleaseIDs:   []bson.ObjectId{},
 		Description:  ns.Description,
 		DateCreated:  time.Now(),

--- a/shelves/models/shelfstore.go
+++ b/shelves/models/shelfstore.go
@@ -33,4 +33,6 @@ type ShelfStore interface {
 	// TODO: export provided shelf as a folder to Dalet
 	// This should probably be a handler function and not a store function
 	ExportShelf(id bson.ObjectId) error
+
+	GetFeaturedShelves() ([]*Shelf, error)
 }


### PR DESCRIPTION
- Closes #30
- Closes #55
- Closes #73 
- Closes #74  
- Closes #76 
 
This PR completes a starting implementation of the shelves service.  As the service requires authentication, it puts authentication necessities into the standard Microservice proxy.  A future commit will create an additional unauthenticated reverse proxy so we can continue testing the library service. 
