### PR TITLE
Mb import

### DIFF
--- a/library/handlers/handlers.go
+++ b/library/handlers/handlers.go
@@ -29,7 +29,8 @@ func (hCtx *HandlerCtx) ReleasesHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		if _, err := uuid.Parse(lastID); err != nil {
-			http.Error(w, fmt.Sprintf("Invalid value for 'last_id': %v", lastID), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("Invalid value for 'last_id': '%v' (should be MBID)", lastID), http.StatusBadRequest)
+			return
 		}
 		releases, err := hCtx.libraryStore.GetReleases(lastID, intLimit)
 		if err != nil {

--- a/library/handlers/handlers.go
+++ b/library/handlers/handlers.go
@@ -11,11 +11,12 @@ import (
 )
 
 // ReleasesHandler path: /v1/library/releases
+// :param: last_id, id of the last release the client saw, for pagination
+// :param: limit, the maximum number of releases to return
 func (hCtx *HandlerCtx) ReleasesHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodPost:
-		// TODO
 		http.Error(w, fmt.Sprintf(HandlerInvalidMethod, r.Method), http.StatusMethodNotAllowed)
 		return
 	case http.MethodGet:
@@ -24,7 +25,6 @@ func (hCtx *HandlerCtx) ReleasesHandler(w http.ResponseWriter, r *http.Request) 
 
 		intLimit, err := strconv.Atoi(limit)
 		if err != nil {
-			// for now this is a 500
 			http.Error(w, fmt.Sprintf("Could not convert 'limit' param value '%v' to integer", limit), http.StatusInternalServerError)
 			return
 		}

--- a/library/indexes/trie.go
+++ b/library/indexes/trie.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"gopkg.in/mgo.v2/bson"
+	"github.com/satori/go.uuid"
 )
 
 type TrieNode struct {
@@ -18,8 +18,8 @@ type TrieNode struct {
 }
 
 type SearchResult struct {
-	ReleaseID      bson.ObjectId `json:"releaseID"`
-	FieldMatchedOn string        `json:"fieldMatchedOn"`
+	ReleaseID      uuid.UUID `json:"releaseID"`
+	FieldMatchedOn string    `json:"fieldMatchedOn"`
 }
 
 func CreateTrieRoot() *TrieNode {
@@ -49,7 +49,7 @@ func (t *TrieNode) AddToTrie(prefix string, searchResult SearchResult) {
 
 }
 
-func (t *TrieNode) nodeContainsRelease(node *TrieNode, releaseID bson.ObjectId) bool {
+func (t *TrieNode) nodeContainsRelease(node *TrieNode, releaseID uuid.UUID) bool {
 	for _, val := range node.SearchResults {
 		if val.ReleaseID == releaseID {
 			return true
@@ -65,7 +65,7 @@ func (t *TrieNode) SearchReleases(prefix string, maxResults int) []SearchResult 
 	if err != nil {
 		return []SearchResult{}
 	}
-	return t.findResultsFromPrefix(startNode, maxResults, []SearchResult{}, make(map[bson.ObjectId]bool))
+	return t.findResultsFromPrefix(startNode, maxResults, []SearchResult{}, make(map[uuid.UUID]bool))
 }
 
 func (t *TrieNode) searchPrefixForNode(prefix string) (*TrieNode, error) {
@@ -83,7 +83,7 @@ func (t *TrieNode) searchPrefixForNode(prefix string) (*TrieNode, error) {
 	return curr, nil
 }
 
-func (t *TrieNode) findResultsFromPrefix(node *TrieNode, maxResults int, results []SearchResult, idsInResults map[bson.ObjectId]bool) []SearchResult {
+func (t *TrieNode) findResultsFromPrefix(node *TrieNode, maxResults int, results []SearchResult, idsInResults map[uuid.UUID]bool) []SearchResult {
 	for _, searchResult := range node.SearchResults {
 
 		_, ok := idsInResults[searchResult.ReleaseID]
@@ -108,7 +108,7 @@ func (t *TrieNode) findResultsFromPrefix(node *TrieNode, maxResults int, results
 	return results
 }
 
-func (t *TrieNode) RemoveKeyAndReleaseID(key string, value bson.ObjectId) error {
+func (t *TrieNode) RemoveKeyAndReleaseID(key string, value uuid.UUID) error {
 	t.mx.Lock()
 	defer t.mx.Unlock()
 	node, err := t.searchPrefixForNode(key)

--- a/library/indexes/trie.go
+++ b/library/indexes/trie.go
@@ -5,8 +5,6 @@ import (
 	"sort"
 	"sync"
 	"unicode/utf8"
-
-	"github.com/google/uuid"
 )
 
 type TrieNode struct {
@@ -18,8 +16,8 @@ type TrieNode struct {
 }
 
 type SearchResult struct {
-	ReleaseID      uuid.UUID `json:"releaseID"`
-	FieldMatchedOn string    `json:"fieldMatchedOn"`
+	ReleaseID      string `json:"releaseID"`
+	FieldMatchedOn string `json:"fieldMatchedOn"`
 }
 
 func CreateTrieRoot() *TrieNode {
@@ -49,7 +47,7 @@ func (t *TrieNode) AddToTrie(prefix string, searchResult SearchResult) {
 
 }
 
-func (t *TrieNode) nodeContainsRelease(node *TrieNode, releaseID uuid.UUID) bool {
+func (t *TrieNode) nodeContainsRelease(node *TrieNode, releaseID string) bool {
 	for _, val := range node.SearchResults {
 		if val.ReleaseID == releaseID {
 			return true
@@ -65,7 +63,7 @@ func (t *TrieNode) SearchReleases(prefix string, maxResults int) []SearchResult 
 	if err != nil {
 		return []SearchResult{}
 	}
-	return t.findResultsFromPrefix(startNode, maxResults, []SearchResult{}, make(map[uuid.UUID]bool))
+	return t.findResultsFromPrefix(startNode, maxResults, []SearchResult{}, make(map[string]bool))
 }
 
 func (t *TrieNode) searchPrefixForNode(prefix string) (*TrieNode, error) {
@@ -83,7 +81,7 @@ func (t *TrieNode) searchPrefixForNode(prefix string) (*TrieNode, error) {
 	return curr, nil
 }
 
-func (t *TrieNode) findResultsFromPrefix(node *TrieNode, maxResults int, results []SearchResult, idsInResults map[uuid.UUID]bool) []SearchResult {
+func (t *TrieNode) findResultsFromPrefix(node *TrieNode, maxResults int, results []SearchResult, idsInResults map[string]bool) []SearchResult {
 	for _, searchResult := range node.SearchResults {
 
 		_, ok := idsInResults[searchResult.ReleaseID]
@@ -108,7 +106,7 @@ func (t *TrieNode) findResultsFromPrefix(node *TrieNode, maxResults int, results
 	return results
 }
 
-func (t *TrieNode) RemoveKeyAndReleaseID(key string, value uuid.UUID) error {
+func (t *TrieNode) RemoveKeyAndReleaseID(key string, value string) error {
 	t.mx.Lock()
 	defer t.mx.Unlock()
 	node, err := t.searchPrefixForNode(key)

--- a/library/indexes/trie.go
+++ b/library/indexes/trie.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 type TrieNode struct {

--- a/library/models/releases/artist.go
+++ b/library/models/releases/artist.go
@@ -7,7 +7,7 @@ import (
 // Artist represents an artist in the KEXP library, with additional
 // information about associated releases
 type Artist struct {
-	ArtistMBID uuid.UUID        `json:"artistMBID" bson:"_id"`
+	ArtistMBID string           `json:"artistMBID" bson:"_id"`
 	Name       string           `json:"name" bson:"name"`
 	Releases   []ReleaseSummary `json:"releases" bson:"releases"`
 }

--- a/library/models/releases/artist.go
+++ b/library/models/releases/artist.go
@@ -1,9 +1,5 @@
 package releases
 
-import (
-	"github.com/google/uuid"
-)
-
 // Artist represents an artist in the KEXP library, with additional
 // information about associated releases
 type Artist struct {
@@ -14,7 +10,7 @@ type Artist struct {
 
 // ReleaseSummary represents a summary of a given release with minimal metadata
 type ReleaseSummary struct {
-	ReleaseMBID uuid.UUID `json:"releaseMBID" bson:"ReleaseMBID"`
-	Title       string    `json:"title" bson:"title"`
+	ReleaseMBID string `json:"releaseMBID" bson:"ReleaseMBID"`
+	Title       string `json:"title" bson:"title"`
 	// ... more fields to be added as needed
 }

--- a/library/models/releases/artist.go
+++ b/library/models/releases/artist.go
@@ -1,7 +1,7 @@
 package releases
 
 import (
-	"github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 // Artist represents an artist in the KEXP library, with additional

--- a/library/models/releases/artist.go
+++ b/library/models/releases/artist.go
@@ -1,16 +1,20 @@
 package releases
 
+import (
+	"github.com/satori/go.uuid"
+)
+
 // Artist represents an artist in the KEXP library, with additional
 // information about associated releases
 type Artist struct {
-	ID       string           `json:"id" bson:"_id"`
-	Name     string           `json:"name" bson:"name"`
-	Releases []ReleaseSummary `json:"releases" bson:"releases"`
+	ArtistMBID uuid.UUID        `json:"artistMBID" bson:"_id"`
+	Name       string           `json:"name" bson:"name"`
+	Releases   []ReleaseSummary `json:"releases" bson:"releases"`
 }
 
 // ReleaseSummary represents a summary of a given release with minimal metadata
 type ReleaseSummary struct {
-	KEXPMBID  string `json:"KEXPMBID" bson:"KEXPMBID"`
-	KEXPTitle string `json:"KEXPTitle" bson:"KEXPTitle"`
+	ReleaseMBID uuid.UUID `json:"releaseMBID" bson:"ReleaseMBID"`
+	Title       string    `json:"title" bson:"title"`
 	// ... more fields to be added as needed
 }

--- a/library/models/releases/libraryStore.go
+++ b/library/models/releases/libraryStore.go
@@ -3,7 +3,7 @@ package releases
 // TODO: general interface should be agnostic of mgo types
 import (
 	"github.com/KEXPCapstone/shelves-server/library/indexes"
-	"github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"gopkg.in/mgo.v2/bson"
 )
 

--- a/library/models/releases/libraryStore.go
+++ b/library/models/releases/libraryStore.go
@@ -3,7 +3,6 @@ package releases
 // TODO: general interface should be agnostic of mgo types
 import (
 	"github.com/KEXPCapstone/shelves-server/library/indexes"
-	"github.com/google/uuid"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -15,10 +14,10 @@ type LibraryStore interface {
 	AddRelease(release *Release) (*Release, error)
 
 	// return all releases in the library
-	GetReleases(lastID uuid.UUID, limit int) ([]*Release, error)
+	GetReleases(lastID string, limit int) ([]*Release, error)
 
 	// return a single release with the supplied id
-	GetReleaseByID(id uuid.UUID) (*Release, error)
+	GetReleaseByID(id string) (*Release, error)
 
 	// return a slice of releases matching the given field value
 	GetReleasesByField(field string, value string) ([]*Release, error)
@@ -27,7 +26,7 @@ type LibraryStore interface {
 	GetArtists(lastID string, limit int) ([]*Artist, error)
 
 	// return a specific artist with the supplied musicbrainz artist MBID
-	GetArtistByMBID(id uuid.UUID) (*Artist, error)
+	GetArtistByMBID(id string) (*Artist, error)
 
 	// return all genres in the library
 	GetGenres(lastID bson.ObjectId, limit int) ([]*Genre, error)

--- a/library/models/releases/libraryStore.go
+++ b/library/models/releases/libraryStore.go
@@ -3,6 +3,7 @@ package releases
 // TODO: general interface should be agnostic of mgo types
 import (
 	"github.com/KEXPCapstone/shelves-server/library/indexes"
+	"github.com/satori/go.uuid"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -14,10 +15,10 @@ type LibraryStore interface {
 	AddRelease(release *Release) (*Release, error)
 
 	// return all releases in the library
-	GetReleases(lastID bson.ObjectId, limit int) ([]*Release, error)
+	GetReleases(lastID uuid.UUID, limit int) ([]*Release, error)
 
 	// return a single release with the supplied id
-	GetReleaseByID(id bson.ObjectId) (*Release, error)
+	GetReleaseByID(id uuid.UUID) (*Release, error)
 
 	// return a slice of releases matching the given field value
 	GetReleasesByField(field string, value string) ([]*Release, error)
@@ -26,7 +27,7 @@ type LibraryStore interface {
 	GetArtists(lastID string, limit int) ([]*Artist, error)
 
 	// return a specific artist with the supplied musicbrainz artist MBID
-	GetArtistByMBID(id string) (*Artist, error)
+	GetArtistByMBID(id uuid.UUID) (*Artist, error)
 
 	// return all genres in the library
 	GetGenres(lastID bson.ObjectId, limit int) ([]*Genre, error)

--- a/library/models/releases/mongostore.go
+++ b/library/models/releases/mongostore.go
@@ -1,9 +1,8 @@
 package releases
 
 import (
+	"log"
 	"strings"
-
-	"github.com/google/uuid"
 
 	"github.com/KEXPCapstone/shelves-server/library/indexes"
 	mgo "gopkg.in/mgo.v2"
@@ -45,7 +44,7 @@ func (ms *MongoStore) AddRelease(release *Release) (*Release, error) {
 
 // GetReleases returns releases in the library greater than 'lastID'
 // 'limit' specifies the max # of releases to return
-func (ms *MongoStore) GetReleases(lastID uuid.UUID, limit int) ([]*Release, error) {
+func (ms *MongoStore) GetReleases(lastID string, limit int) ([]*Release, error) {
 	coll := ms.session.DB(ms.dbname).C(ms.releaseCollection)
 	releases := []*Release{}
 	if err := coll.Find(bson.M{"_id": bson.M{"$gt": lastID}}).Limit(limit).All(&releases); err != nil {
@@ -55,10 +54,12 @@ func (ms *MongoStore) GetReleases(lastID uuid.UUID, limit int) ([]*Release, erro
 }
 
 // GetReleaseByID returns a single release in the library
-func (ms *MongoStore) GetReleaseByID(id uuid.UUID) (*Release, error) {
+func (ms *MongoStore) GetReleaseByID(id string) (*Release, error) {
+	log.Printf("UUID: '%v'", id)
 	coll := ms.session.DB(ms.dbname).C(ms.releaseCollection)
 	release := &Release{}
 	if err := coll.FindId(id).One(release); err != nil {
+		log.Print(err)
 		return nil, err
 	}
 	return release, nil
@@ -117,7 +118,7 @@ func (ms *MongoStore) GetArtists(lastID string, limit int) ([]*Artist, error) {
 }
 
 // GetArtistByMBID returns a specific artist matching the supplied id (MusicBrainz artist MBID)
-func (ms *MongoStore) GetArtistByMBID(id uuid.UUID) (*Artist, error) {
+func (ms *MongoStore) GetArtistByMBID(id string) (*Artist, error) {
 	coll := ms.session.DB(ms.dbname).C(ms.artistCollection)
 	artist := &Artist{}
 	if err := coll.FindId(id).One(artist); err != nil {

--- a/library/models/releases/mongostore.go
+++ b/library/models/releases/mongostore.go
@@ -3,7 +3,7 @@ package releases
 import (
 	"strings"
 
-	"github.com/satori/go.uuid"
+	"github.com/google/uuid"
 
 	"github.com/KEXPCapstone/shelves-server/library/indexes"
 	mgo "gopkg.in/mgo.v2"

--- a/library/models/releases/release.go
+++ b/library/models/releases/release.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/KEXPCapstone/shelves-server/library/indexes"
 
-	"github.com/google/uuid"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -13,7 +12,7 @@ import (
 // with a combination of fields from KEXP's own records, MetaData from MusicBrainz
 // and custom fields related to the 'shelves' application
 type Release struct {
-	ID                      uuid.UUID     `json:"id" bson:"_id"`
+	ID                      string        `json:"id" bson:"_id"`
 	ArtistCredit            []interface{} `json:"artistCredit" bson:"artist-credit"`
 	ReleaseEvents           []interface{} `json:"releaseEvents" bson:"release-events"`
 	CoverArtArchive         interface{}   `json:"coverArtArchive" bson:"cover-art-archive"`

--- a/library/models/releases/release.go
+++ b/library/models/releases/release.go
@@ -4,93 +4,48 @@ import (
 	"time"
 
 	"github.com/KEXPCapstone/shelves-server/library/indexes"
+
+	"github.com/satori/go.uuid"
 	"gopkg.in/mgo.v2/bson"
 )
 
-// type Release struct {
-// 	ID              bson.ObjectId   `json:"id" bson:"_id"`
-// 	Artist          string          `json:"artist"`
-// 	Title           string          `json:"title"`
-// 	ReleaseYear     string          `json:"releaseYear"`
-// 	KEXPCategory    string          `json:"KEXPCategory"`
-// 	Label           string          `json:"label"`
-// 	MusicBrainzInfo MusicBrainzMeta `json:"musicBrainzInfo"`
-// 	DiscogsURL      string          `json:"discogsURL"`
-// 	DaletID         string          `json:"daletID"`
-// 	TrackList       []Track         `json:"trackList"`
-// 	Notes           []Note          `json:"notes"`
-// 	// Add image URL?
-// }
-
 // Release represents a single release for an album in the KEXP library
+// with a combination of fields from KEXP's own records, MetaData from MusicBrainz
+// and custom fields related to the 'shelves' application
 type Release struct {
-	ID                            bson.ObjectId `json:"id" bson:"_id"`
-	KEXPPrimaryGenre              string        `json:"KEXPPrimaryGenre" bson:"KEXPPrimaryGenre"`
-	KEXPMBID                      string        `json:"KEXPMBID" bson:"KEXPMBID"`
-	KEXPDateReleased              string        `json:"KEXPDateReleased" bson:"KEXPDateReleased"`
-	KEXPFirstReleaseDate          string        `json:"KEXPFirstReleaseDate" bson:"KEXPFirstReleaseDate"`
-	KEXPLength                    string        `json:"KEXPLength" bson:"KEXPLength"`
-	KEXPReleaseCatalogNumber      string        `json:"KEXPReleaseCatalogNumber" bson:"KEXPReleaseCatalogNumber"` // couldn't find
-	KEXPReleaseGroupMBID          string        `json:"KEXPReleaseGroupMBID" bson:"KEXPReleaseGroupMBID"`
-	KEXPTitle                     string        `json:"KEXPTitle" bson:"KEXPTitle"`
-	KEXPUniqueTitle               string        `json:"KEXPUniqueTitle" bson:"KEXPUniqueTitle"`
-	KEXPReleaseArtistCredit       string        `json:"KEXPReleaseArtistCredit" bson:"KEXPReleaseArtistCredit"`
-	KEXPArtist                    string        `json:"KEXPArtist" bson:"KEXPArtist"`
-	KEXPLabel                     string        `json:"KEXPLabel" bson:"KEXPLabel"`
-	KEXPReleasePackaging          string        `json:"KEXPReleasePackaging" bson:"KEXPReleasePackaging"`
-	KEXPReleasePrimaryType        string        `json:"KEXPReleasePrimaryType" bson:"KEXPReleasePrimaryType"`
-	KEXPReleaseSecondaryType      string        `json:"KEXPReleaseSecondaryType" bson:"KEXPReleaseSecondaryType"`
-	KEXPReleaseStatus             string        `json:"KEXPReleaseStatus" bson:"KEXPReleaseStatus"`
-	KEXPArtist_KEXPAlias          string        `json:"KEXPArtist_KEXPAlias" bson:"KEXPArtist_KEXPAlias"`
-	KEXPArtist_KEXPArtistType     string        `json:"KEXPArtist_KEXPArtistType" bson:"KEXPArtist_KEXPArtistType"`
-	KEXPArtist_KEXPDisambiguation string        `json:"KEXPArtist_KEXPDisambiguation" bson:"KEXPArtist_KEXPDisambiguation"`
-	KEXPArtist_KEXPLink           string        `json:"KEXPArtist_KEXPLink" bson:"KEXPArtist_KEXPLink"`
-	KEXPArtist_KEXPMBID           string        `json:"KEXPArtist_KEXPMBID" bson:"KEXPArtist_KEXPMBID"`
-	KEXPArtist_KEXPName           string        `json:"KEXPArtist_KEXPName" bson:"KEXPArtist_KEXPName"`
-	KEXPArtist_KEXPSortName       string        `json:"KEXPArtist_KEXPSortName" bson:"KEXPArtist_KEXPSortName"`
-	KEXPLabel_KEXPMBID            string        `json:"KEXPLabel_KEXPMBID" bson:"KEXPLabel_KEXPMBID"`
-	KEXPLabel_KEXPName            string        `json:"KEXPLabel_KEXPName" bson:"KEXPLabel_KEXPName"`
-	KEXPLabel_KEXPSortName        string        `json:"KEXPLabel_KEXPSortName" bson:"KEXPLabel_KEXPSortName"`
-	KEXPArea                      string        `json:"KEXPArea" bson:"KEXPArea"`
-	KEXPAreaMBID                  string        `json:"KEXPAreaMBID" bson:"KEXPAreaMBID"`
-	KEXPCountryCode               string        `json:"KEXPCountryCode" bson:"KEXPCountryCode"`
+	ID                      uuid.UUID     `json:"id" bson:"_id"`
+	ArtistCredit            []interface{} `json:"artistCredit" bson:"artist-credit"`
+	ReleaseEvents           []interface{} `json:"releaseEvents" bson:"release-events"`
+	CoverArtArchive         interface{}   `json:"coverArtArchive" bson:"cover-art-archive"`
+	KEXPReleaseGroupMBID    string        `json:"KEXPReleaseGroupMBID" bson:"KEXPReleaseGroupMBID"`
+	KEXPReleaseArtistCredit string        `json:"KEXPReleaseArtistCredit" bson:"KEXPReleaseArtistCredit"`
+	LabelInfo               []interface{} `json:"labelInfo" bson:"label-info"`
+	Media                   string        `json:"media" bson:"media"`
+	Status                  string        `json: "status" bson: "status"`
+	Disambiguation          string        `json: "disambiguation" bson: "disambiguation"`
+	Barcode                 string        `json:"barcode" bson:"barcode"`
+	Packaging               string        `json:"packaging" bson:"packaging"`
+	Date                    string        `json:"date" bson:"date"`
+	ASIN                    string        `json:"asin" bson:"asin"`
+	KEXPPrimaryGenre        string        `json:"KEXPPrimaryGenre" bson:"KEXPPrimaryGenre"`
+	Title                   string        `json:"title" bson:"title"`
+	CountryCode             string        `json:"countryCode" bson:"country"`
+	Yellows                 []int         `json:"yellows" bson:"yellows"`
+	Reds                    []int         `json:"reds" bson:"reds"`
 }
 
-type MusicBrainzMeta struct {
-	MBID string `json:"mbid"`
-	// TODO: All of the meta that we want.
-}
-
-type Track struct {
-	Name      string `json:"name"`
-	Length    string `json:"length"`
-	FCCRating string `json:"FCCRating"`
-}
-
+// ReleaseAndMatchCriteria represents a pairing of
+// a release object and a match criteria from a search index
 type ReleaseAndMatchCriteria struct {
 	Release   *Release             `json:"release"`
 	IndexInfo indexes.SearchResult `json:"indexInfo"`
 }
 
+// Note represents a note/comment for a given release
 type Note struct {
 	Author      string        `json:"author"`
 	Comment     string        `json:"comment"`
 	UserID      bson.ObjectId `json:"userID"`
 	DateCreated time.Time     `json:"dateCreated"`
-	// TODO: Decide if editing notes is out of scope or not
 	// DateLastEdit time.Time     `json:"dateLastEdit"`
 }
-
-// func (dr *DaletRelease) ProcessDaletRelease() (*Release, error) {
-
-// 		1). Load in Data from Dalet into DaletRelease
-// 			a). Handle scenarios of missing data.
-// 		2). Fetch data from MusicBrainz
-// 			a). Producers
-// 			b). Building track lists?
-// 			c). Any other fields
-// 		3). Copy fields into Release struct with associated BSON ID
-// 		4). Place Release into Mongo.
-
-// 	return nil, nil
-// }

--- a/library/models/releases/release.go
+++ b/library/models/releases/release.go
@@ -19,7 +19,7 @@ type Release struct {
 	KEXPReleaseGroupMBID    string        `json:"KEXPReleaseGroupMBID" bson:"KEXPReleaseGroupMBID"`
 	KEXPReleaseArtistCredit string        `json:"KEXPReleaseArtistCredit" bson:"KEXPReleaseArtistCredit"`
 	LabelInfo               []interface{} `json:"labelInfo" bson:"label-info"`
-	Media                   string        `json:"media" bson:"media"`
+	Media                   []interface{} `json:"media" bson:"media"`
 	Status                  string        `json:"status" bson:"status"`
 	Disambiguation          string        `json:"disambiguation" bson:"disambiguation"`
 	Barcode                 string        `json:"barcode" bson:"barcode"`

--- a/library/models/releases/release.go
+++ b/library/models/releases/release.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/KEXPCapstone/shelves-server/library/indexes"
 
-	"github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"gopkg.in/mgo.v2/bson"
 )
 

--- a/library/models/releases/release.go
+++ b/library/models/releases/release.go
@@ -20,8 +20,8 @@ type Release struct {
 	KEXPReleaseArtistCredit string        `json:"KEXPReleaseArtistCredit" bson:"KEXPReleaseArtistCredit"`
 	LabelInfo               []interface{} `json:"labelInfo" bson:"label-info"`
 	Media                   string        `json:"media" bson:"media"`
-	Status                  string        `json: "status" bson: "status"`
-	Disambiguation          string        `json: "disambiguation" bson: "disambiguation"`
+	Status                  string        `json:"status" bson:"status"`
+	Disambiguation          string        `json:"disambiguation" bson:"disambiguation"`
 	Barcode                 string        `json:"barcode" bson:"barcode"`
 	Packaging               string        `json:"packaging" bson:"packaging"`
 	Date                    string        `json:"date" bson:"date"`


### PR DESCRIPTION
- makes significant changes to the fields in our Release struct, to accomodate data from MusicBrainz
- Release doc ids are now release MBIDs
- simple UUID validation of query params for release get requests
- treat IDs as strings in librarystore