### PR TITLE
Xuser unauth error

### DIFF
--- a/library/handlers/constants.go
+++ b/library/handlers/constants.go
@@ -23,3 +23,5 @@ const ErrorSearching = "Error processing release results: "
 const XUser = "X-User"
 
 const ErrInvalidXUser = "Invalid ID in X-User header. You may have been signed out."
+
+const ErrNoXUser = "Invalid or no X-User header. You may have been signed out."

--- a/library/handlers/handlers.go
+++ b/library/handlers/handlers.go
@@ -170,12 +170,12 @@ func (hCtx *HandlerCtx) insertNote(w http.ResponseWriter, r *http.Request) {
 	nn := &releases.NewNote{}
 	userID, err := getUserIDFromRequest(r)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("%v", ErrNoXUser), http.StatusUnauthorized)
 		return
 	}
 	authorName, err := getNameFromRequest(r)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("%v", ErrNoXUser), http.StatusUnauthorized)
 		return
 	}
 	if err := json.NewDecoder(r.Body).Decode(nn); err != nil {

--- a/shelves/handlers/constants.go
+++ b/shelves/handlers/constants.go
@@ -37,3 +37,5 @@ const UserShelvesHandlerMethodNotAllowed = "Only allowed to 'GET' from this reso
 const InvalidUserID = "Invalid user ID in request URL."
 
 const FeaturedShelvesHandlerMethodNotAllowed = "Only allowed to 'GET' from this resource."
+
+const ErrNoXUser = "Invalid or no X-User header. You may have been signed out."

--- a/shelves/handlers/handlers.go
+++ b/shelves/handlers/handlers.go
@@ -18,7 +18,7 @@ func (hCtx *HandlerCtx) ShelvesMineHandler(w http.ResponseWriter, r *http.Reques
 	case http.MethodGet:
 		userID, idErr := getUserIDFromRequest(r)
 		if idErr != nil {
-			http.Error(w, fmt.Sprintf("%v", idErr), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("%v", ErrNoXUser), http.StatusUnauthorized)
 			return
 		}
 		hCtx.getUsersShelvesFromID(w, r, userID)

--- a/shelves/handlers/handlers.go
+++ b/shelves/handlers/handlers.go
@@ -176,12 +176,12 @@ func (hCtx *HandlerCtx) addShelf(w http.ResponseWriter, r *http.Request) {
 	ns := &models.NewShelf{}
 	userID, err := getUserIDFromRequest(r)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("%v", ErrNoXUser), http.StatusUnauthorized)
 		return
 	}
 	ownerName, err := getNameFromRequest(r)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("%v", ErrNoXUser), http.StatusUnauthorized)
 		return
 	}
 	if err := json.NewDecoder(r.Body).Decode(ns); err != nil {


### PR DESCRIPTION
Updates error message when unauthorized user requests their shelves, tries to post a note, or add a shelf.
Fixes #97 